### PR TITLE
sockets.ts: check this.destroyed in _write() methods (related to #17)

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -47,7 +47,11 @@ class SCTPStreamWritable extends Writable {
 
     this.bytesWritten += chunk.length
 
-    this.socket.bufferedCustomWrite(chunk, options, callback)
+    this.socket.bufferedCustomWrite(chunk, options, () => {
+      if (!this.destroyed && callback) {
+        callback()
+      }
+    })
   }
 }
 
@@ -121,7 +125,11 @@ class Socket extends Duplex {
 
     this.bytesWritten += chunk.length
 
-    this.bufferedCustomWrite(chunk, options, callback)
+    this.bufferedCustomWrite(chunk, options, () => {
+      if (!this.destroyed && callback) {
+        callback()
+      }
+    })
   }
 
   bufferedCustomWrite (chunk, options, callback) {


### PR DESCRIPTION
Related to https://github.com/latysheff/node-sctp/issues/17:

Check `this.destroyed` in both `_write()` methods in `sockets.js` so the given `callback` is not executed if the socket/stream is already destroyed.