### PR TITLE
sockets.ts: check this.destroyed in _write() methods (related to #17)

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -48,7 +48,9 @@ class SCTPStreamWritable extends Writable {
 
     this.bytesWritten += chunk.length
 
-    this.socket.sendToAssociation(chunk, options, callback)
+    this.socket.sendToAssociation(chunk, options, () => {
+      if (!this.destroyed) callback()
+    })
   }
 }
 
@@ -119,7 +121,9 @@ class Socket extends Duplex {
 
     this.bytesWritten += chunk.length
 
-    this.sendToAssociation(chunk, options, callback)
+    this.sendToAssociation(chunk, options, () => {
+      if (!this.destroyed) callback()
+    })
   }
 
   sendToAssociation (chunk, options, callback) {


### PR DESCRIPTION
Related to https://github.com/latysheff/node-sctp/issues/17:

Check `this.destroyed` in both `_write()` methods in `sockets.js` so the given `callback` is not executed if the socket/stream is already destroyed.